### PR TITLE
Remove Ruby nos Trilhos because it's not available anymore

### DIFF
--- a/material/dir/sites.md
+++ b/material/dir/sites.md
@@ -7,7 +7,6 @@
 - [Official Rails Blog](http://weblog.rubyonrails.org/)
 - [OneBitCode](https://onebitcode.com/)
 - [Pro Rails Blog](https://prograils.com/blog)
-- [Ruby nos trilhos](http://rubynostrilhos.com.br/)
 - [Ruby Steps](https://www.rubysteps.com)
 - [Ruby Flow Blog](http://www.rubyflow.com/)
 - [Ruby Tapas](https://www.rubytapas.com/)


### PR DESCRIPTION
Oi pessoal,

Estou removendo esse blog da lista porque ele não está disponível mais.

Ele era meu, estou planejando escrever em pt-br no http://grokblog.io/, mas ainda não adicionei o toggle the língua nele.

Obrigado. =)